### PR TITLE
Fixes #20 Adding support for Raspbian

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Supported versions
 | Devuan Jessie (1)     | Yes     | No                      |
 | Devuan Ascii (2)      | Yes     | No                      |
 | Kali Linux            | Yes     | No                      |
+| Raspbian Stretch (9)  | TBD     | No                      |
+| Raspbian Buster (10)  | TBD     | No                      |
 | Ubuntu Bionic (18.04) | Yes     | No                      |
 
 Requirements

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,6 +16,7 @@ Vagrant.configure("2") do |config|
     { :name => "devuan-ascii",            :box => "https://files.devuan.org/devuan_ascii/virtual/devuan_ascii_2.0.0_amd64_vagrant.box" },
     { :name => "kali",                    :box => "offensive-security/kali-linux-light", :vars => { dbs_use_systemd: true  } },
     { :name => "kali-sysvinit",           :box => "offensive-security/kali-linux-light", :vars => { dbs_use_systemd: false } },
+    { :name => "raspbian-stretch",        :box => "gvfoster/raspbian",:vars => { dbs_use_systemd: true } },
     { :name => "ubuntu-bionic",           :box => "ubuntu/bionic64",  :vars => { dbs_use_systemd: true  } },
   ]
 

--- a/tasks/000-fixes.yml
+++ b/tasks/000-fixes.yml
@@ -23,3 +23,8 @@
   set_fact:
     ansible_distribution: "Kali"
   when: ansible_distribution is match ('^[Kk]ali')
+
+- name: SET_FACT | Fix Raspbian fact
+  set_fact:
+    ansible_distribution: 'Raspbian'
+  when: ansible_lsb.id is match ('^[Rr]aspbian')

--- a/tasks/000-fixes.yml
+++ b/tasks/000-fixes.yml
@@ -24,6 +24,10 @@
     ansible_distribution: "Kali"
   when: ansible_distribution is match ('^[Kk]ali')
 
+- name: DEBUG | Debug ansible_lsb.id value
+  debug:
+    var: ansible_lsb.id
+
 - name: SET_FACT | Fix Raspbian fact
   set_fact:
     ansible_distribution: 'Raspbian'

--- a/tasks/000-fixes.yml
+++ b/tasks/000-fixes.yml
@@ -24,11 +24,7 @@
     ansible_distribution: "Kali"
   when: ansible_distribution is match ('^[Kk]ali')
 
-- name: DEBUG | Debug ansible_lsb.id value
-  debug:
-    var: ansible_lsb.id
-
 - name: SET_FACT | Fix Raspbian fact
   set_fact:
     ansible_distribution: 'Raspbian'
-  when: ansible_lsb.id is match ('^[Rr]aspbian')
+  when: (ansible_lsb.id is defined) and (ansible_lsb.id is match ('^[Rr]aspbian'))

--- a/vars/Raspbian/buster.yml
+++ b/vars/Raspbian/buster.yml
@@ -1,0 +1,1 @@
+dbs_distro_packages: ["ohai"]

--- a/vars/Raspbian/main.yml
+++ b/vars/Raspbian/main.yml
@@ -1,0 +1,5 @@
+---
+dbs_apt_default_host: "mirrordirector.raspbian.org"
+dbs_apt_components: "main contrib non-free rpi"
+dbs_repo_new:
+  - "http://{{ dbs_apt_default_host }}/raspbian {{ ansible_distribution_release }} {{ dbs_apt_components }}"

--- a/vars/Raspbian/stretch.yml
+++ b/vars/Raspbian/stretch.yml
@@ -1,0 +1,1 @@
+dbs_distro_packages: ["ohai"]


### PR DESCRIPTION
After taking a look at [rhietala/raspberry-ansible](https://github.com/rhietala/raspberry-ansible), I've added a new module in 000-fixes.yml that fixes the ansible_distribution fact when ansible_lsb.id == Raspbian.

Also added new var files Raspbian Stretch and Buster.

Only thing I didn't add but think would be a good addition would be to change the password for the pi user.