### PR TITLE
Bump to version 2.0.0

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,2 @@
+enable_list:
+  - fqcn-builtins

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ services:
 before_install:
   - sudo apt-get -q update
   - sudo apt-get install -y yamllint
-  - sudo wget -nv https://releases.hashicorp.com/vagrant/$VAGRANT_VERSION/vagrant_$VAGRANT_VERSION_x86_64.deb
-  - sudo dpkg -i vagrant_$VAGRANT_VERSION_x86_64.deb
+  - sudo wget -nv https://releases.hashicorp.com/vagrant/${VAGRANT_VERSION}/vagrant_${VAGRANT_VERSION}_x86_64.deb
+  - sudo dpkg -i vagrant_${VAGRANT_VERSION}_x86_64.deb
 
 install:
   - sudo pip install "ansible-core$ANSIBLE_VERSION"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   allow_failures:
-    - env: PLATFORM='docker-debian-bullseye' ANSIBLE_VERSION='>=2.11,<2.12'
+    - env: PLATFORM='docker-ubuntu-bionic'   ANSIBLE_VERSION='>=2.11,<2.12'
 
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,18 @@
+---
+
 env:
-  - PLATFORM='docker-debian-jessie'  ANSIBLE_VERSION='ansible>=2.9,<2.10'
-  - PLATFORM='docker-debian-stretch' ANSIBLE_VERSION='ansible>=2.9,<2.10'
-  - PLATFORM='docker-debian-buster'  ANSIBLE_VERSION='ansible>=2.9,<2.10'
-  - PLATFORM='docker-ubuntu-bionic'  ANSIBLE_VERSION='ansible>=2.9,<2.10'
+  - PLATFORM='docker-debian-stretch'  ANSIBLE_VERSION='>=2.11,<2.12'
+  - PLATFORM='docker-debian-bullseye' ANSIBLE_VERSION='>=2.11,<2.12'
+  - PLATFORM='docker-debian-buster'   ANSIBLE_VERSION='>=2.11,<2.12'
+  - PLATFORM='docker-ubuntu-bionic'   ANSIBLE_VERSION='>=2.11,<2.12'
 
-sudo: required
+jobs:
+  allow_failures:
+    - env: PLATFORM='docker-debian-bullseye' ANSIBLE_VERSION='>=2.11,<2.12'
 
-dist: trusty
+os:
+  - linux
+dist: focal
 
 language: python
 python:
@@ -17,11 +23,14 @@ services:
   - docker
 
 before_install:
+  - sudo apt-get -q update
   - wget https://releases.hashicorp.com/vagrant/2.0.1/vagrant_2.0.1_x86_64.deb
   - sudo dpkg -i vagrant_2.0.1_x86_64.deb
+  - sudo apt-get install -y yamllint
 
 install:
-  - pip install "$ANSIBLE_VERSION"
+  - pip install "ansible-core$ANSIBLE_VERSION"
+  - ansible-galaxy collection install ansible.posix
 
 script:
   - VAGRANT_DEFAULT_PROVIDER=docker vagrant up $PLATFORM
@@ -31,6 +40,14 @@ script:
     && (echo 'Idempotence test: pass' && exit 0)
     || (echo 'Idempotence test: fail' && exit 1)
   - VAGRANT_DEFAULT_PROVIDER=docker vagrant status
+  - >
+    yaml-lint .
+    && (echo 'YAML lint test: pass' && exit 0)
+    || (echo 'YAML lint test: fail' && exit 1)
+  - >
+    ansible-lint -v tests/test.yml
+    && (echo 'Ansible lint test: pass' && exit 0)
+    || (echo 'Ansible lint test: fail' && exit 1)
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
 install:
   - sudo pip install "ansible-core$ANSIBLE_VERSION"
   - sudo pip install ansible-lint
-  - ansible-galaxy collection install ansible.posix
+  - ansible-galaxy collection install ansible.posix community.general
 
 script:
   - VAGRANT_DEFAULT_PROVIDER=docker vagrant up $PLATFORM

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,13 @@ services:
 
 before_install:
   - sudo apt-get -q update
-  - sudo apt-get install -y vagrant yamllint
+  - sudo apt-get install -y yamllint
+  - sudo wget -nv https://releases.hashicorp.com/vagrant/2.2.7/vagrant_2.2.7_x86_64.deb
+  - sudo dpkg -i vagrant_2.2.7_x86_64.deb
 
 install:
-  - pip install "ansible-core$ANSIBLE_VERSION"
+  - sudo pip install "ansible-core$ANSIBLE_VERSION"
+  - sudo pip install ansible-lint 
   - ansible-galaxy collection install ansible.posix
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,7 @@ dist: focal
 
 language: python
 python:
-  - 2.7
-  - 3.6
+  - 3.8
 
 services:
   - docker
@@ -41,7 +40,7 @@ script:
     || (echo 'Idempotence test: fail' && exit 1)
   - VAGRANT_DEFAULT_PROVIDER=docker vagrant status
   - >
-    yaml-lint .
+    yamllint .
     && (echo 'YAML lint test: pass' && exit 0)
     || (echo 'YAML lint test: fail' && exit 1)
   - >

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,7 @@ services:
 
 before_install:
   - sudo apt-get -q update
-  - wget https://releases.hashicorp.com/vagrant/2.0.1/vagrant_2.0.1_x86_64.deb
-  - sudo dpkg -i vagrant_2.0.1_x86_64.deb
-  - sudo apt-get install -y yamllint
+  - sudo apt-get install -y vagrant yamllint
 
 install:
   - pip install "ansible-core$ANSIBLE_VERSION"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 ---
 
 env:
-  - PLATFORM='docker-debian-stretch'  ANSIBLE_VERSION='>=2.11,<2.12'
-  - PLATFORM='docker-debian-bullseye' ANSIBLE_VERSION='>=2.11,<2.12'
-  - PLATFORM='docker-debian-buster'   ANSIBLE_VERSION='>=2.11,<2.12'
-  - PLATFORM='docker-ubuntu-bionic'   ANSIBLE_VERSION='>=2.11,<2.12'
+  global:
+    - VAGRANT_VERSION='2.2.18'
+  jobs:
+    - PLATFORM='docker-debian-stretch'  ANSIBLE_VERSION='>=2.11,<2.12'
+    - PLATFORM='docker-debian-bullseye' ANSIBLE_VERSION='>=2.11,<2.12'
+    - PLATFORM='docker-debian-buster'   ANSIBLE_VERSION='>=2.11,<2.12'
+    - PLATFORM='docker-ubuntu-bionic'   ANSIBLE_VERSION='>=2.11,<2.12'
 
 jobs:
   allow_failures:
@@ -24,8 +27,8 @@ services:
 before_install:
   - sudo apt-get -q update
   - sudo apt-get install -y yamllint
-  - sudo wget -nv https://releases.hashicorp.com/vagrant/2.2.7/vagrant_2.2.7_x86_64.deb
-  - sudo dpkg -i vagrant_2.2.7_x86_64.deb
+  - sudo wget -nv https://releases.hashicorp.com/vagrant/$VAGRANT_VERSION/vagrant_$VAGRANT_VERSION_x86_64.deb
+  - sudo dpkg -i vagrant_$VAGRANT_VERSION_x86_64.deb
 
 install:
   - sudo pip install "ansible-core$ANSIBLE_VERSION"

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
 
 install:
   - sudo pip install "ansible-core$ANSIBLE_VERSION"
-  - sudo pip install ansible-lint 
+  - sudo pip install ansible-lint
   - ansible-galaxy collection install ansible.posix
 
 script:

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,4 @@
+---
+
+rules:
+  line-length: disable

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-Ansible Debian/Devuan/Kali/Ubuntu/Raspbian bootstrap
+Ansible Debian/Devuan/Ubuntu/Raspbian bootstrap
 ====================================================
 
-[![Ansible Galaxy](http://img.shields.io/badge/ansible--galaxy-HanXHX.debian_bootstrap-blue.svg)](https://galaxy.ansible.com/HanXHX/debian_bootstrap) [![Build Status](https://travis-ci.org/HanXHX/ansible-debian-bootstrap.svg?branch=master)](https://travis-ci.org/HanXHX/ansible-debian-bootstrap)
+[![Ansible Galaxy](http://img.shields.io/badge/ansible--galaxy-HanXHX.debian_bootstrap-blue.svg)](https://galaxy.ansible.com/HanXHX/debian_bootstrap) [![Build Status](https://travis-ci.com/HanXHX/ansible-debian-bootstrap.svg?branch=master)](https://travis-ci.com/HanXHX/ansible-debian-bootstrap)
 
-This role bootstraps Debian/Devuan/Kali/Ubuntu/Raspbian hosts:
+This role bootstraps Debian/Devuan/Ubuntu/Raspbian hosts:
 
 - Configure APT (sources.list)
 - Install minimal packages (vim, htop...)
@@ -20,12 +20,10 @@ Supported versions
 
 | OS                    | Working      | Stable (active support) |
 | --------------------- | -------      | ----------------------- |
-| Debian Jessie (8)     | Yes          | Yes                     |
 | Debian Stretch (9)    | Yes          | Yes                     |
 | Debian Buster (10)    | Yes          | Yes                     |
-| Devuan Jessie (1)     | Yes          | No                      |
+| Debian Bullseye (11)  | Yes          | Yes                     |
 | Devuan Ascii (2)      | Yes          | No                      |
-| Kali Linux            | Partial      | No                      |
 | Raspbian Stretch (9)  | Experimental | No                      |
 | Raspbian Buster (10)  | Experimental | No                      |
 | Ubuntu Bionic (18.04) | Yes          | No                      |
@@ -33,7 +31,8 @@ Supported versions
 Requirements
 ------------
 
-Min Ansible 2.9
+- Ansible >= 2.11
+- Collections: [ansible.posix collection](https://galaxy.ansible.com/ansible/posix) / [community.general](https://galaxy.ansible.com/community/general)
 
 Role Variables
 --------------

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Ansible Debian/Devuan/Ubuntu/Raspbian bootstrap
 ====================================================
 
-[![Ansible Galaxy](http://img.shields.io/badge/ansible--galaxy-HanXHX.debian_bootstrap-blue.svg)](https://galaxy.ansible.com/HanXHX/debian_bootstrap) [![Build Status](https://travis-ci.com/HanXHX/ansible-debian-bootstrap.svg?branch=master)](https://travis-ci.com/HanXHX/ansible-debian-bootstrap)
+[![Ansible Galaxy](http://img.shields.io/badge/ansible--galaxy-HanXHX.debian_bootstrap-blue.svg)](https://galaxy.ansible.com/HanXHX/debian_bootstrap) [![Build Status](https://app.travis-ci.com/HanXHX/ansible-debian-bootstrap.svg?branch=master)](https://app.travis-ci.com/HanXHX/ansible-debian-bootstrap)
 
 This role bootstraps Debian/Devuan/Ubuntu/Raspbian hosts:
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,25 +6,22 @@
 Vagrant.configure("2") do |config|
 
   vms_debian = [
-    { :name => "debian-jessie",           :box => "debian/jessie64",  :vars => { dbs_use_systemd: true, dbs_set_apt: false  } },
-    { :name => "debian-jessie-sysvinit",  :box => "debian/jessie64",  :vars => { dbs_use_systemd: false, dbs_set_apt: false} },
-    { :name => "debian-stretch",          :box => "debian/stretch64", :vars => { dbs_use_systemd: true  } },
-    { :name => "debian-stretch-sysvinit", :box => "debian/stretch64", :vars => { dbs_use_systemd: false } },
-    { :name => "debian-buster",           :box => "debian/buster64",  :vars => { dbs_use_systemd: true  } },
-    { :name => "debian-buster-sysvinit",  :box => "debian/buster64",  :vars => { dbs_use_systemd: false } },
-    { :name => "devuan-jessie",           :box => "https://files.devuan.org/devuan_jessie/virtual/devuan_jessie_1.0.0_amd64_vagrant.box" },
-    { :name => "devuan-ascii",            :box => "https://files.devuan.org/devuan_ascii/virtual/devuan_ascii_2.0.0_amd64_vagrant.box" },
-    { :name => "kali",                    :box => "offensive-security/kali-linux-light", :vars => { dbs_use_systemd: true  } },
-    { :name => "kali-sysvinit",           :box => "offensive-security/kali-linux-light", :vars => { dbs_use_systemd: false } },
-    { :name => "raspbian-stretch",        :box => "gvfoster/raspbian",:vars => { dbs_use_systemd: true } },
-    { :name => "ubuntu-bionic",           :box => "ubuntu/bionic64",  :vars => { dbs_use_systemd: true  } },
+    { :name => "debian-stretch",           :box => "debian/stretch64", :vars => { dbs_use_systemd: true  } },
+    { :name => "debian-stretch-sysvinit",  :box => "debian/stretch64", :vars => { dbs_use_systemd: false } },
+    { :name => "debian-buster",            :box => "debian/buster64",  :vars => { dbs_use_systemd: true  } },
+    { :name => "debian-buster-sysvinit",   :box => "debian/buster64",  :vars => { dbs_use_systemd: false } },
+    { :name => "debian-bullseye",          :box => "debian/bullseye64",  :vars => { dbs_use_systemd: true  } },
+    { :name => "debian-bullseye-sysvinit", :box => "debian/bullseye64",  :vars => { dbs_use_systemd: false } },
+    { :name => "devuan-ascii",             :box => "https://files.devuan.org/devuan_ascii/virtual/devuan_ascii_2.0.0_amd64_vagrant.box" },
+    { :name => "raspbian-stretch",         :box => "gvfoster/raspbian",:vars => { dbs_use_systemd: true } },
+    { :name => "ubuntu-bionic",            :box => "ubuntu/bionic64",  :vars => { dbs_use_systemd: true  } },
   ]
 
   conts = [
-    { :name => "docker-debian-jessie",  :docker => "hanxhx/vagrant-ansible:debian8", :vars => { dbs_set_apt: false } },
-    { :name => "docker-debian-stretch", :docker => "hanxhx/vagrant-ansible:debian9", :vars => {} },
-    { :name => "docker-debian-buster",  :docker => "hanxhx/vagrant-ansible:debian10", :vars => {} },
-    { :name => "docker-ubuntu-bionic",  :docker => "hanxhx/vagrant-ansible:ubuntu18.04", :vars => {} }
+    { :name => "docker-debian-stretch",  :docker => "hanxhx/vagrant-ansible:debian9", :vars => {} },
+    { :name => "docker-debian-buster",   :docker => "hanxhx/vagrant-ansible:debian10", :vars => {} },
+    { :name => "docker-debian-bullseye", :docker => "hanxhx/vagrant-ansible:debian11", :vars => {} },
+    { :name => "docker-ubuntu-bionic",   :docker => "hanxhx/vagrant-ansible:ubuntu18.04", :vars => {} }
   ]
 
   config.vm.network "private_network", type: "dhcp"
@@ -36,6 +33,11 @@ Vagrant.configure("2") do |config|
         d.remains_running = true
         d.has_ssh = true
       end
+
+      if opts[:name].include? "bullseye"
+        m.vm.provision "shell", inline: "apt-get update -qq && apt-get -y dist-upgrade"
+      end
+
       m.vm.provision "ansible" do |ansible|
         ansible.playbook = "tests/test.yml"
         ansible.verbose = 'vv'
@@ -51,16 +53,21 @@ Vagrant.configure("2") do |config|
       if opts[:name].include? "devuan" or opts[:name].include? "ubuntu"
         m.vm.provision "shell", inline: "apt-get update -qq && apt-get -y install python"
       end
+
+      if opts[:name].include? "bullseye"
+        m.vm.provision "shell", inline: "apt-get update -qq && apt-get -y dist-upgrade"
+      end
+
       if opts[:name].include? "devuan"
         m.vm.box_url = opts[:box]
         m.vm.box = opts[:name]
       else
         m.vm.box = opts[:box]
       end
+
       m.vm.provider "virtualbox" do |v|
         v.cpus = 1
-        v.memory = 256
-        v.gui = false # Force hide gui with Kali Linux
+        v.memory = 512
       end
       m.vm.provision "ansible" do |ansible|
         ansible.playbook = "tests/test.yml"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -35,7 +35,7 @@ Vagrant.configure("2") do |config|
       end
 
       if opts[:name].include? "bullseye"
-        m.vm.provision "shell", inline: "apt-get update -qq && apt-get -y dist-upgrade"
+        m.vm.provision "shell", inline: "[ -f '/root/first_provision' ] || (apt-get update -qq && apt-get -y dist-upgrade && touch /root/first_provision)"
       end
 
       m.vm.provision "ansible" do |ansible|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -75,6 +75,7 @@ Vagrant.configure("2") do |config|
         ansible.become = true
         ansible.extra_vars = opts[:vars]
         ansible.raw_arguments = ["-D"]
+        ansible.compatibility_mode = "2.0"
       end
     end
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -44,6 +44,7 @@ Vagrant.configure("2") do |config|
         ansible.become = true
         ansible.extra_vars = opts[:vars]
         ansible.raw_arguments = ["-D"]
+        ansible.compatibility_mode = "2.0"
       end
     end
   end

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,5 @@
+---
+
 # -------------------------
 # APT configuration
 # -------------------------
@@ -57,60 +59,60 @@ dbs_groups: []
 # Sysctl
 # -------------------------
 dbs_sysctl_config:
-### IMPROVE SYSTEM MEMORY MANAGEMENT ###
-# Increase size of file handles and inode cache
+  ### IMPROVE SYSTEM MEMORY MANAGEMENT ###
+  # Increase size of file handles and inode cache
   'fs.file-max': '2097152'
-# Do less swapping
+  # Do less swapping
   'vm.swappiness': '10'
   'vm.dirty_ratio': '60'
   'vm.dirty_background_ratio': '2'
-### GENERAL NETWORK SECURITY OPTIONS ###
-# Number of times SYNACKs for passive TCP connection.
+  ### GENERAL NETWORK SECURITY OPTIONS ###
+  # Number of times SYNACKs for passive TCP connection.
   'net.ipv4.tcp_synack_retries': '2'
-# Allowed local port range
+  # Allowed local port range
   'net.ipv4.ip_local_port_range': '2000 65535'
-# Protect Against TCP Time-Wait
+  # Protect Against TCP Time-Wait
   'net.ipv4.tcp_rfc1337': '1'
-# Decrease the time default value for tcp_fin_timeout connection
+  # Decrease the time default value for tcp_fin_timeout connection
   'net.ipv4.tcp_fin_timeout': '15'
-# Decrease the time default value for connections to keep alive
+  # Decrease the time default value for connections to keep alive
   'net.ipv4.tcp_keepalive_time': '300'
   'net.ipv4.tcp_keepalive_probes': '5'
   'net.ipv4.tcp_keepalive_intvl': '15'
-# Resist SYN flood attack
+  # Resist SYN flood attack
   'net.ipv4.tcp_syncookies': '1'
-### TUNING NETWORK PERFORMANCE ###
-# Default Socket Receive Buffer
+  ### TUNING NETWORK PERFORMANCE ###
+  # Default Socket Receive Buffer
   'net.core.rmem_default': '31457280'
-# Maximum Socket Receive Buffer
+  # Maximum Socket Receive Buffer
   'net.core.rmem_max': '12582912'
-# Default Socket Send Buffer
+  # Default Socket Send Buffer
   'net.core.wmem_default': '31457280'
-# Maximum Socket Send Buffer
+  # Maximum Socket Send Buffer
   'net.core.wmem_max': '12582912'
-# Increase number of incoming connections
+  # Increase number of incoming connections
   'net.core.somaxconn': '65536'
-# Increase number of incoming connections backlog
+  # Increase number of incoming connections backlog
   'net.core.netdev_max_backlog': '65536'
-# Increase the maximum amount of option memory buffers
+  # Increase the maximum amount of option memory buffers
   'net.core.optmem_max': '25165824'
-# Increase the maximum total buffer-space allocatable
-# This is measured in units of pages (4096 bytes)
+  # Increase the maximum total buffer-space allocatable
+  # This is measured in units of pages (4096 bytes)
   'net.ipv4.tcp_mem': '65536 131072 262144'
   'net.ipv4.udp_mem': '65536 131072 262144'
-# Increase the read-buffer space allocatable
+  # Increase the read-buffer space allocatable
   'net.ipv4.tcp_rmem': '8192 87380 16777216'
   'net.ipv4.udp_rmem_min': '16384'
-# Increase the write-buffer-space allocatable
+  # Increase the write-buffer-space allocatable
   'net.ipv4.tcp_wmem': '8192 65536 16777216'
   'net.ipv4.udp_wmem_min': '16384'
-# Increase the tcp-time-wait buckets pool size to prevent simple DOS attacks
+  # Increase the tcp-time-wait buckets pool size to prevent simple DOS attacks
   'net.ipv4.tcp_max_tw_buckets': '1440000'
-# Reuse TIME-WAIT state for outgoing connexion (safe)
+  # Reuse TIME-WAIT state for outgoing connexion (safe)
   'net.ipv4.tcp_tw_reuse': '1'
-# Increase system IP port limits to allow for more connections
+  # Increase system IP port limits to allow for more connections
   'net.ipv4.tcp_window_scaling': '1'
-# number of packets to keep in backlog before the kernel starts dropping them
+  # number of packets to keep in backlog before the kernel starts dropping them
   'net.ipv4.tcp_max_syn_backlog': '3240000'
 
 # Internal use (DO NOT UPDATE)

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -8,6 +8,7 @@
 - name: restart ntp
   ansible.builtin.service:
     name: ntp
+    state: restarted
 
 - name: restart cron
   ansible.builtin.service:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,21 +1,31 @@
 ---
+
 - name: restart openntpd
-  service: name=openntpd state=restarted
+  ansible.builtin.service:
+    name: openntpd
+    state: restarted
 
 - name: restart ntp
-  service: name=ntp state=restarted
+  ansible.builtin.service:
+    name: ntp
 
 - name: restart cron
-  service: name=cron state=restarted
+  ansible.builtin.service:
+    name: cron
+    state: restarted
 
 - name: restart rsyslog
-  service: name=rsyslog state=restarted
+  ansible.builtin.service:
+    name: rsyslog
+    state: restarted
 
 - name: update tzdata
-  command: dpkg-reconfigure -f noninteractive tzdata
+  ansible.builtin.command: dpkg-reconfigure -f noninteractive tzdata
 
 - name: locale-gen
-  command: locale-gen
+  ansible.builtin.command: locale-gen
 
 - name: reload networking
-  service: name=networking state=reloaded
+  ansible.builtin.service:
+    name: networking
+    state: reloaded

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,33 +1,33 @@
 ---
+
 galaxy_info:
+  role_name: debian_bootstrap
+  namespace: HanXHX
   author: Emilien Mantel
-  description: Normalize and prepare a Debian/Devuan/Kali Linux server
+  description: Normalize and prepare a Debian/Devuan/Ubuntu Linux server
   company:
   license: GPLv2
-  min_ansible_version: 2.9
+  min_ansible_version: 2.11
   platforms:
-  - name: Debian
-    versions:
-    - jessie
-    - stretch
-    - buster
-  - name: Devuan
-    versions:
-    - jessie
-    - ascii
-  - name: Kali Linux
-    versions:
-    - rolling-kali
-  - name: Ubuntu
-    versions:
-    - bionic
+    - name: Debian
+      versions:
+        - stretch
+        - buster
+        - bullseye
+    - name: Devuan
+      versions:
+        - ascii
+    - name: Ubuntu
+      versions:
+        - bionic
   galaxy_tags:
-  - networking
-  - packaging
-  - system
-  - debian
-  - apt
-  - alternatives
-  - editor
-  - ntp
+    - networking
+    - packaging
+    - system
+    - debian
+    - apt
+    - alternatives
+    - editor
+    - ntp
+
 dependencies: []

--- a/tasks/000-fixes.yml
+++ b/tasks/000-fixes.yml
@@ -1,30 +1,25 @@
 ---
 
-- name: SET_FACT | Bypass https://github.com/ansible/ansible/issues/19874
-  set_fact:
-    ansible_distribution_release: 'buster'
-  when: ansible_facts.distribution_major_version == "buster/sid"
+- name: FAIL | Check OS name
+  ansible.builtin.fail:
+    msg: 'Cannot get OS version name. Unstable {{ ansible_distribution }} release? Please try `apt-get dist-upgrade`.'
+  when: ansible_distribution_release == 'n/a' or ansible_distribution_release == 'NA'
 
 - block:
 
-  - name: COMMAND | Get Devuan release
-    command: cat /etc/devuan_version
-    register: osr
-    changed_when: false
+    - name: COMMAND | Get Devuan release
+      ansible.builtin.command: cat /etc/devuan_version
+      register: osr
+      changed_when: false
 
-  - name: SET_FACT | Fix Devuan fact
-    set_fact:
-      ansible_distribution: "Devuan"
-      ansible_distribution_release: "{{ osr.stdout }}"
+    - name: SET_FACT | Fix Devuan fact
+      ansible.builtin.set_fact:
+        ansible_distribution: "Devuan"
+        ansible_distribution_release: "{{ osr.stdout }}"
 
   when: ansible_distribution is match ('^[dD]evuan')
 
-- name: SET_FACT | Fix Kali fact
-  set_fact:
-    ansible_distribution: "Kali"
-  when: ansible_distribution is match ('^[Kk]ali')
-
 - name: SET_FACT | Fix Raspbian fact
-  set_fact:
+  ansible.builtin.set_fact:
     ansible_distribution: 'Raspbian'
   when: (ansible_lsb.id is defined) and (ansible_lsb.id is match ('^[Rr]aspbian'))

--- a/tasks/apt.yml
+++ b/tasks/apt.yml
@@ -1,81 +1,85 @@
 ---
 
 - name: COPY | Configure APT no extra packages
-  copy:
+  ansible.builtin.copy:
     src: etc/apt/apt.conf.d/90noextrapackages
     dest: /etc/apt/apt.conf.d/90noextrapackages
+    mode: 0644
+    owner: root
+    group: root
 
 # We MUST update cache... Ansible auto install python-apt
 - name: APT | Update
-  apt:
-    update_cache: yes
+  ansible.builtin.apt:
+    update_cache: true
     cache_valid_time: 3600
   changed_when: false
 
 - block:
+    - name: FILE | Delete default repository (sources.list)
+      ansible.builtin.file:
+        path: /etc/apt/sources.list
+        state: absent
 
-  - name: FILE | Delete default repository (sources.list)
-    file:
-      path: /etc/apt/sources.list
-      state: absent
+    - name: APT_REPOSITORY | Delete old deb repo
+      ansible.builtin.apt_repository:
+        repo: "deb {{ item }}"
+        state: absent
+      when: item not in dbs_repo_new
+      loop: "{{ dbs_repo_old }}"
 
-  - name: APT_REPOSITORY | Delete old deb repo
-    apt_repository:
-      repo: "deb {{ item }}"
-      state: absent
-    when: item not in dbs_repo_new
-    with_items: "{{ dbs_repo_old }}"
+    - name: APT_REPOSITORY | Delete old deb-src repo
+      ansible.builtin.apt_repository:
+        repo: "deb-src {{ item }}"
+        state: absent
+      when: item not in dbs_repo_new
+      loop: "{{ dbs_repo_old }}"
 
-  - name: APT_REPOSITORY | Delete old deb-src repo
-    apt_repository:
-      repo: "deb-src {{ item }}"
-      state: absent
-    when: item not in dbs_repo_new
-    with_items: "{{ dbs_repo_old }}"
+    - name: APT_REPOSITORY | Add repositories
+      ansible.builtin.apt_repository:
+        repo: "deb {{ item }}"
+        state: present
+        update_cache: false
+      register: ar
+      loop: "{{ dbs_repo_new }}"
 
-  - name: APT_REPOSITORY | Add repositories
-    apt_repository:
-      repo: "deb {{ item }}"
-      state: present
-      update_cache: no
-    register: ar
-    with_items: "{{ dbs_repo_new }}"
+    - name: APT_REPOSITORY | Add src repositories
+      ansible.builtin.apt_repository:
+        repo: "deb-src {{ item }}"
+        state: "{{ 'present' if dbs_apt_use_src else 'absent' }}"
+        update_cache: false
+      register: ars
+      loop: "{{ dbs_repo_new }}"
 
-  - name: APT_REPOSITORY | Add src repositories
-    apt_repository:
-      repo: "deb-src {{ item }}"
-      state: "{{ 'present' if dbs_apt_use_src else 'absent' }}"
-      update_cache: no
-    register: ars
-    with_items: "{{ dbs_repo_new }}"
+    - name: COPY | Manage current repositories
+      ansible.builtin.copy:
+        content: "{ \"dbs_repo_old\": {{ dbs_repo_new | to_json }} }"
+        dest: /etc/ansible/facts.d/apt_sources.fact
+        mode: 0644
+        owner: root
+        group: root
 
-  - name: COPY | Manage current repositories
-    copy:
-      content: "{ \"dbs_repo_old\": {{ dbs_repo_new | to_json }} }"
-      dest: /etc/ansible/facts.d/apt_sources.fact
-
-  - name: APT | Update cache if necessary
-    apt: update_cache=yes
-    when: ar.changed or ars.changed
-    tags:
-      - skip_ansible_lint
+    - name: APT | Update cache if necessary
+      ansible.builtin.apt:
+        update_cache: true
+      when: ar.changed or ars.changed
 
   when: dbs_set_apt
 
 - name: APT | Uninstall packages
-  apt:
+  ansible.builtin.apt:
     pkg: "{{ dbs_uninstall_packages }}"
     state: absent
 
 - name: APT | Install few packages
-  apt:
+  ansible.builtin.apt:
     pkg: "{{ lookup('flattened', dbs_packages, dbs_distro_packages) }}"
     state: present
-    update_cache: yes
+    update_cache: true
     cache_valid_time: 3600
 
 - name: APT | Install Intel Microcode if needed
-  apt:
+  ansible.builtin.apt:
     pkg: intel-microcode
     state: present
     default_release: '{{ dbs_microcode_apt_distribution }}'
@@ -84,7 +88,7 @@
     ansible_architecture == 'x86_64'
 
 - name: APT | Install AMD Microcode if needed
-  apt:
+  ansible.builtin.apt:
     pkg: amd64-microcode
     state: present
     default_release: '{{ dbs_microcode_apt_distribution }}'

--- a/tasks/hostname.yml
+++ b/tasks/hostname.yml
@@ -1,15 +1,18 @@
 ---
 
 - name: HOSTNAME
-  hostname:
+  ansible.builtin.hostname:
     name: "{{ dbs_hostname }}"
     use: "{% if dbs_hostname_use_strategy is not none %}{{ dbs_hostname_use_strategy }}{% elif ansible_service_mgr == 'systemd' %}systemd{% else %}debian{% endif %}"
   notify: restart rsyslog
   register: change_hostname
 
 - name: TEMPLATE | Cleanup /etc/hosts
-  template:
+  ansible.builtin.template:
     src: etc/hosts.j2
     dest: /etc/hosts
+    mode: 0644
+    owner: root
+    group: root
   notify: restart rsyslog
   when: dbs_clean_hosts

--- a/tasks/locale.yml
+++ b/tasks/locale.yml
@@ -1,13 +1,16 @@
 ---
 
 - name: LOCALE | Add
-  locale_gen:
+  community.general.locale_gen:
     name: "{{ item }}"
     state: present
   with_items: "{{ dbs_locales }}"
   notify: locale-gen
 
 - name: TEMPLATE | Deploy default locale
-  template:
+  ansible.builtin.template:
     src: etc/default/locale.j2
     dest: /etc/default/locale
+    mode: 0644
+    owner: root
+    group: root

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,7 +30,7 @@
   when: dbs_set_hostname and not dbs_is_docker
 
 - name: TIMEZONE | Set
-  ansible.builtin.timezone:
+  community.general.timezone:
     name: "{{ dbs_timezone }}"
   when: dbs_set_timezone
   notify:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,47 +1,48 @@
 ---
 
-- name: INCLUDE | Some fixes
-  include: 000-fixes.yml
+- name: IMPORT_TASKS | Some fixes
+  ansible.builtin.import_tasks: 000-fixes.yml
 
 - name: INCLUDE_VARS | OS
-  include_vars: "{{ ansible_distribution }}/main.yml"
+  ansible.builtin.include_vars: "{{ ansible_distribution }}/main.yml"
 
 - name: INCLUDE_VARS | Related to OS version
-  include_vars: "{{ ansible_distribution }}/{{ ansible_distribution_release }}.yml"
+  ansible.builtin.include_vars: "{{ ansible_distribution }}/{{ ansible_distribution_release }}.yml"
 
-- name: INCLUDE | Prepare system
-  include: prepare.yml
+- name: IMPORT_TASKS | Prepare system
+  ansible.builtin.import_tasks: prepare.yml
 
-- name: INCLUDE | Configure APT
-  include: apt.yml
+- name: IMPORT_TASKS | Configure APT
+  ansible.builtin.import_tasks: apt.yml
 
-- name: INCLUDE | Manage system users
-  include: user.yml
+- name: IMPORT_TASKS | Manage system users
+  ansible.builtin.import_tasks: user.yml
 
-- name: INCLUDE | Kick systemd
-  include: nosystemd.yml
+- name: INCLUDE_TASKS | Kick systemd
+  ansible.builtin.include_tasks: nosystemd.yml
   when: >
     ansible_distribution == 'Debian' and
     not dbs_use_systemd and
     not dbs_is_docker
 
-- name: INCLUDE | Set hostname
-  include: hostname.yml
+- name: INCLUDE_TASKS | Set hostname
+  ansible.builtin.include_tasks: hostname.yml
   when: dbs_set_hostname and not dbs_is_docker
 
 - name: TIMEZONE | Set
-  timezone:
+  ansible.builtin.timezone:
     name: "{{ dbs_timezone }}"
   when: dbs_set_timezone
-  notify: [ restart cron ]
+  notify:
+    - 'restart cron'
 
-- name: INCLUDE | Manage locales
-  include: locale.yml
+- name: INCLUDE_TASKS | Manage locales
+  ansible.builtin.include_tasks: locale.yml
   when: dbs_set_locale
 
-- name: INCLUDE | Install NTP damon
-  include: ntp.yml
+- name: INCLUDE_TASKS | Install NTP damon
+  ansible.builtin.include_tasks: ntp.yml
   when: dbs_set_ntp
 
-- name: INCLUDE | Misc system configuration
-  include: system.yml
+- name: IMPORT_TASKS | Misc system configuration
+  ansible.builtin.import_tasks: system.yml

--- a/tasks/nosystemd.yml
+++ b/tasks/nosystemd.yml
@@ -1,36 +1,32 @@
 ---
 
 - name: APT | Install sysvinit
-  apt:
+  ansible.builtin.apt:
     pkg: "{{ dbs_sysvinit_packages }}"
     state: present
   register: sysv_installed
 
 - block:
 
-  - name: SHELL | Reboot machine
-    shell: sleep 2 && shutdown -r now "Ansible updates triggered"
-    async: 1
-    poll: 0
-    ignore_errors: true
+    - name: REBOOT
+      ansible.builtin.reboot:
+        timeout: 3600
 
-  - name: WAIT_FOR_CONNECTION | Wait while rebooting...
-    wait_for_connection:
-      delay: 30
-      timeout: 600
-
-  - name: SETUP
-    action: setup
+    - name: SETUP
+      ansible.builtin.setup:
 
   when: sysv_installed.changed
 
 - name: APT | Purge systemd
-  apt:
+  ansible.builtin.apt:
     pkg: systemd
     state: absent
-    purge: yes
+    purge: true
 
 - name: COPY | Configure APT no extra packages
-  copy:
+  ansible.builtin.copy:
     src: etc/apt/preferences.d/systemd
     dest: /etc/apt/preferences.d/systemd
+    mode: 0644
+    owner: root
+    group: root

--- a/tasks/ntp.yml
+++ b/tasks/ntp.yml
@@ -1,24 +1,30 @@
 ---
 
 - name: ASSERT | validated package
-  assert:
+  ansible.builtin.assert:
     that: 'dbs_ntp_pkg == "openntpd" or dbs_ntp_pkg == "ntp"'
 
 - name: APT | Install NTP daemon
-  apt:
+  ansible.builtin.apt:
     pkg: "{{ dbs_ntp_pkg }}"
     state: present
 
 - name: TEMPLATE | Deploy OpenNTPd configuration file
-  template:
+  ansible.builtin.template:
     src: etc/openntpd/ntpd.conf.j2
     dest: /etc/openntpd/ntpd.conf
+    mode: 0644
+    owner: root
+    group: root
   notify: restart openntpd
   when: dbs_ntp_pkg == 'openntpd'
 
 - name: TEMPLATE | Deploy NTPd configuration file
-  template:
+  ansible.builtin.template:
     src: etc/ntp.conf.j2
     dest: /etc/ntp.conf
+    mode: 0644
+    owner: root
+    group: root
   notify: restart ntp
   when: dbs_ntp_pkg == 'ntp'

--- a/tasks/prepare.yml
+++ b/tasks/prepare.yml
@@ -1,10 +1,13 @@
 ---
 
 - name: FILE | Creates ansible facts.d
-  file:
+  ansible.builtin.file:
     path: /etc/ansible/facts.d
     state: directory
+    mode: 0755
+    owner: root
+    group: root
 
 - name: SET_FACT | Is docker?
-  set_fact:
+  ansible.builtin.set_fact:
     dbs_is_docker: "{{ false if ansible_virtualization_type is not defined or ansible_virtualization_type != 'docker' else true }}"

--- a/tasks/system.yml
+++ b/tasks/system.yml
@@ -1,29 +1,24 @@
 ---
 
-- name: UPDATE-ALTERNATIVE | Editor
-  alternatives:
-    name: editor
-    path: "{{ dbs_alternative_editor }}"
-
-- name: UPDATE-ALTERNATIVE | Awk
-  alternatives:
-    name: awk
-    path: "{{ dbs_alternative_awk }}"
-
-- name: UPDATE-ALTERNATIVE | Netcat
-  alternatives:
-    name: nc
-    path: "{{ dbs_alternative_netcat }}"
-
-- name: UPDATE-ALTERNATIVE | Gawk (GNU awk) is the best
-  alternatives:
-    name: awk
-    path: "{{ dbs_alternative_awk }}"
+- name: ALTERNATIVES | Set commons
+  community.general.alternatives:
+    name: "{{ item.name }}"
+    path: "{{ item.path }}"
+  loop:
+    - name: "awk"
+      path: "{{ dbs_alternative_awk }}"
+    - name: "editor"
+      path: "{{ dbs_alternative_editor }}"
+    - name: "nc"
+      path: "{{ dbs_alternative_netcat }}"
 
 - name: COPY | dotfiles for root
-  copy:
+  ansible.builtin.copy:
     src: "{{ item }}"
     dest: "/root/.{{ item }}"
+    mode: 0640
+    owner: root
+    group: root
   with_items:
     - "bashrc"
     - "vimrc"
@@ -32,7 +27,7 @@
   when: dbs_use_dotfiles
 
 - name: SYSCTL | Tuning
-  sysctl:
+  ansible.posix.sysctl:
     name: "{{ item.key }}"
     value: "{{ item.value }}"
     sysctl_file: /etc/sysctl.d/ansible.conf

--- a/tasks/user.yml
+++ b/tasks/user.yml
@@ -1,15 +1,14 @@
 ---
 
 - name: GROUP | Add groups to the system
-  group:
+  ansible.builtin.group:
     name: "{{ item.name }}"
     system: "{{ item.system | default('no') }}"
-  with_items:
-    - "{{ dbs_groups }}"
+  loop: "{{ dbs_groups }}"
   when: item.state is not defined or item.state == 'present'
 
 - name: USER | Add users to the system
-  user:
+  ansible.builtin.user:
     name: "{{ item.name }}"
     shell: "{{ item.shell | default(omit) }}"
     comment: "{{ item.comment | default('') }}"
@@ -23,14 +22,14 @@
   with_items: "{{ dbs_users }}"
 
 - name: GROUP | Delete groups to the system
-  group:
+  ansible.builtin.group:
     name: "{{ item.name }}"
     state: absent
   with_items: "{{ dbs_groups }}"
   when: item.state is defined and item.state == 'absent'
 
 - name: USER | Add to group
-  user:
+  ansible.builtin.user:
     name: "{{ item.name }}"
     group: "{{ item.group }}"
   with_items: "{{ dbs_users }}"
@@ -39,7 +38,7 @@
     (item.state is not defined or item.state == 'present')
 
 - name: AUTHORIZED_KEY | Install SSH public key to system users
-  authorized_key:
+  ansible.posix.authorized_key:
     user: "{{ item.0.name }}"
     key: "{{ item.1 }}"
   with_subelements:
@@ -50,7 +49,7 @@
   when: item.0.state is not defined or item.0.state == 'present'
 
 - name: TEMPLATE | Create sudoers file
-  template:
+  ansible.builtin.template:
     src: etc/sudoers.d/ansible.j2
     dest: /etc/sudoers.d/ansible
     mode: 0440

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -8,7 +8,7 @@
     dbs_groups:
       - name: 'administrator'
       - name: 'superdaemon'
-        system: yes
+        system: true
       - name: 'regis'
         state: 'absent'
     dbs_users:
@@ -24,7 +24,7 @@
         clear_password: '1a2b3c'
         update_password: 'on_create'
       - name: 'gunther'
-        password: '$6$fFXafeiTssSG3LX3$/ji4TrTVWJwQdgKeLs69OtmXbpe6faCw7XCO5xzHSv3FqVdHA0qjgs01ZovYQBt./5vH5eUVT7XeOpb0PRtQh/' # tralala
+        password: '$6$fFXafeiTssSG3LX3$/ji4TrTVWJwQdgKeLs69OtmXbpe6faCw7XCO5xzHSv3FqVdHA0qjgs01ZovYQBt./5vH5eUVT7XeOpb0PRtQh/'   # tralala
         shell: '/bin/bash'
       - name: 'regis'
         state: 'absent'
@@ -36,12 +36,12 @@
     - ../../
   post_tasks:
     - name: -- TEST -- COMMAND | Get timezone
-      command: cat /etc/timezone
+      ansible.builtin.command: cat /etc/timezone
       changed_when: false
       register: ntz
     - name: -- TEST -- ASSERT | We have good timezone
-      assert:
+      ansible.builtin.assert:
         that: "ntz.stdout == dbs_timezone"
     - name: -- TEST -- COMMAND | Date
-      command: date
+      ansible.builtin.command: date
       changed_when: false

--- a/vars/Debian/bullseye.yml
+++ b/vars/Debian/bullseye.yml
@@ -1,0 +1,4 @@
+---
+
+# Note ohai is not available... Fix it later.
+dbs_distro_packages: []

--- a/vars/Debian/buster.yml
+++ b/vars/Debian/buster.yml
@@ -1,1 +1,3 @@
+---
+
 dbs_distro_packages: ["ohai"]

--- a/vars/Debian/jessie.yml
+++ b/vars/Debian/jessie.yml
@@ -1,2 +1,0 @@
-dbs_distro_packages: ["ohai"]
-dbs_sysvinit_packages: ["sysvinit-core", "sysvinit", "sysvinit-utils"]

--- a/vars/Debian/main.yml
+++ b/vars/Debian/main.yml
@@ -3,5 +3,10 @@
 dbs_repo_new:
   - "http://{{ dbs_apt_default_host }}/debian {{ ansible_distribution_release }} {{ dbs_apt_components }}"
   - "http://{{ dbs_apt_default_host }}/debian {{ ansible_distribution_release }}-updates {{ dbs_apt_components }}"
-  - "http://security.debian.org/ {{ ansible_distribution_release }}/updates {{ dbs_apt_components }}"
+  - "{{ dbs_repo_security if (ansible_distribution_version is version('11', '>=')) else dbs_repo_security_legacy }}"
   - "http://{{ dbs_apt_default_host }}/debian {{ ansible_distribution_release }}-backports {{ dbs_apt_components }}"
+
+# Security repo pattern from Debian 11
+dbs_repo_security: "http://security.debian.org/debian-security {{ ansible_distribution_release }}-security {{ dbs_apt_components }}"
+# Legacy security repo
+dbs_repo_security_legacy: "http://security.debian.org/ {{ ansible_distribution_release }}/updates {{ dbs_apt_components }}"

--- a/vars/Debian/stretch.yml
+++ b/vars/Debian/stretch.yml
@@ -1,1 +1,3 @@
+---
+
 dbs_distro_packages: ["ohai"]

--- a/vars/Devuan/ascii.yml
+++ b/vars/Devuan/ascii.yml
@@ -1,1 +1,3 @@
+---
+
 dbs_distro_packages: ["ohai"]

--- a/vars/Devuan/jessie.yml
+++ b/vars/Devuan/jessie.yml
@@ -1,2 +1,0 @@
-dbs_distro_packages: ["ohai"]
-dbs_sysvinit_packages: []

--- a/vars/Kali/kali-rolling.yml
+++ b/vars/Kali/kali-rolling.yml
@@ -1,3 +1,0 @@
----
-
-# Empty file

--- a/vars/Kali/main.yml
+++ b/vars/Kali/main.yml
@@ -1,5 +1,0 @@
----
-dbs_distro_packages: []
-dbs_apt_default_host: 'http.kali.org'
-dbs_repo_new:
-  - "http://{{ dbs_apt_default_host }}/kali {{ ansible_distribution_release }} {{ dbs_apt_components }}"

--- a/vars/Raspbian/buster.yml
+++ b/vars/Raspbian/buster.yml
@@ -1,1 +1,3 @@
+---
+
 dbs_distro_packages: ["ohai"]

--- a/vars/Raspbian/main.yml
+++ b/vars/Raspbian/main.yml
@@ -1,4 +1,5 @@
 ---
+
 dbs_apt_default_host: "mirrordirector.raspbian.org"
 dbs_apt_components: "main contrib non-free rpi"
 dbs_repo_new:

--- a/vars/Raspbian/stretch.yml
+++ b/vars/Raspbian/stretch.yml
@@ -1,1 +1,3 @@
+---
+
 dbs_distro_packages: ["ohai"]

--- a/vars/Ubuntu/bionic.yml
+++ b/vars/Ubuntu/bionic.yml
@@ -1,1 +1,3 @@
+---
+
 dbs_distro_packages: ["ohai"]

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,5 @@
+---
+
 dbs_packages:
   - apt-transport-https
   - aptitude


### PR DESCRIPTION
- Modern Ansible (use collections)
- Use linter on CI
- Migrate from legacy Travis to new Travis
- Add Debian Bullseye (11) support
- Drop Debian Jessie and Kali Linux support
